### PR TITLE
Rework Allure volume definition

### DIFF
--- a/charts/allure/Chart.yaml
+++ b/charts/allure/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Allure Report
 
 type: application
 
-version: 0.0.3
+version: 0.0.4
 
 appVersion: "2.17.2"

--- a/charts/allure/templates/deployment-api.yaml
+++ b/charts/allure/templates/deployment-api.yaml
@@ -1,7 +1,8 @@
+{{- $fullName := include "allure.fullname" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "allure.fullname" . }}-api
+  name: {{ $fullName }}-api
   labels:
     {{- include "allure-api.labels" . | nindent 4 }}
 spec:
@@ -32,7 +33,7 @@ spec:
           imagePullPolicy: {{ .Values.image.api.pullPolicy }}
           envFrom:
             - configMapRef:
-                name: {{ include "allure.fullname" . }}-api
+                name: {{ $fullName }}-api
             - secretRef:
                 name: {{ .Values.credentials }}
           volumeMounts:
@@ -54,6 +55,9 @@ spec:
             {{- toYaml .Values.resources.api | nindent 12 }}
       volumes:
         - name: reports-volume
+          {{- if not .Values.volume.enabled }}
+          emptyDir: {}
+          {{- else }}
           persistentVolumeClaim:
-            claimName: {{ include "allure.fullname" . }}-api
- 
+            claimName: {{ .Values.volume.existingClaim | default (printf "%s-data" $fullName) }}
+          {{- end }}

--- a/charts/allure/templates/volume-api.yaml
+++ b/charts/allure/templates/volume-api.yaml
@@ -1,12 +1,18 @@
-
+{{- if and (.Values.volume.enabled) (not .Values.volume.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "allure.fullname" . }}-api
+  name: {{ include "allure.fullname" . }}-data
+  labels:
+    {{- include "allure-api.selectorLabels" . | nindent 4 }}
 spec:
+{{- with .Values.volume }}
   accessModes:
-    - ReadWriteOnce
+    {{- toYaml .accessModes | nindent 4 }}
   volumeMode: Filesystem
-  storageClassName: {{ .Values.volume.className }}
+  storageClassName: {{ .storageClassName }}
   resources:
-    {{- toYaml .Values.volume.resources | nindent 4 }}
+    requests:
+      storage: {{ .size }}
+{{- end }}
+{{- end }}

--- a/charts/allure/values.yaml
+++ b/charts/allure/values.yaml
@@ -84,10 +84,12 @@ credentials: api-credentials
 
 # Allure History and Reports Storage Resources
 volume:
-  className: default
-  resources:
-    requests:
-      storage: 4Gi
+  enabled: true
+  storageClassName: ""
+  size: 4Gi
+  existingClaim: ""
+  accessModes:
+    - ReadWriteMany
 
 # For Large Allure Results:
 # - Increase Connection Timeout


### PR DESCRIPTION
- Allow to toggle PersistentVolumeClaim and storage
- Set default accessMode to RWX (as multiple Replicas cannot access a single PVC)
