### PR TITLE
Release Chart Errbot v0.0.2

### DIFF
--- a/charts/errbot/Chart.yaml
+++ b/charts/errbot/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
   - name: David Girón
     url: https://github.com/duhow
 
-version: 0.0.1
+version: 0.0.2
 # renovate: datasource=docker depName=errbotio/errbot
 appVersion: 6.1.9
 

--- a/charts/errbot/templates/application.yaml
+++ b/charts/errbot/templates/application.yaml
@@ -73,7 +73,8 @@ spec:
         workingDir: {{ .Values.persistence.path }}
         env:
         - name: PLUGIN_LIST
-          value: {{ .Values.plugins | join " " }}
+          value: >-
+            {{ range .Values.plugins }}{{ .repo }} {{ end }}
         command: ["/bin/bash"]
         args:
         - -c
@@ -87,6 +88,30 @@ spec:
             [ ! -e "$PLUGIN" ] && git clone --depth=1 https://github.com/${PLUGIN} ${PLUGIN} || true;
             done
         volumeMounts:
+        - name: errbot-data
+          mountPath: {{ .Values.persistence.path }}
+      {{- end }}
+      {{- if .Values.config.storage }}
+      - name: config-storage
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+        {{- with .Values.image }}
+        image: "{{ .repository }}:{{ .tag | default $.Chart.AppVersion }}"
+        imagePullPolicy: {{ .pullPolicy }}
+        {{- end }}
+        workingDir: {{ .Values.persistence.path }}
+        command: ["/bin/bash"]
+        args:
+        - -c
+        - |-
+          {{- range .Values.config.storage }}
+            echo {{ .values | toJson | quote }} | errbot {{ printf "--storage-%s" .strategy }} {{ .name }};
+          {{- end }}
+        volumeMounts:
+        - name: errbot-config
+          readOnly: true
+          mountPath: {{ .Values.config.path }}
+          subPath: config.py
         - name: errbot-data
           mountPath: {{ .Values.persistence.path }}
       {{- end }}

--- a/charts/errbot/templates/application.yaml
+++ b/charts/errbot/templates/application.yaml
@@ -124,6 +124,10 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- with .Values.lifecycle }}
+        lifecycle:
+          {{- . | toYaml | nindent 12 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:
@@ -133,6 +137,8 @@ spec:
           subPath: config.py
         - name: errbot-data
           mountPath: {{ .Values.persistence.path }}
+        tty: {{ .Values.tty }}
+        stdin: {{ .Values.stdin }}
       {{- with .Values.extraContainers }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/errbot/templates/application.yaml
+++ b/charts/errbot/templates/application.yaml
@@ -47,7 +47,17 @@ spec:
         imagePullPolicy: {{ .pullPolicy }}
         {{- end }}
         workingDir: {{ .Values.persistence.path }}
-        command: [errbot, --init]
+        command: ["/bin/bash"]
+        args:
+        - -c
+        - |-
+            if [ ! -d "data" ] && [ ! -d "plugins" ]; then
+            errbot --init;
+            rm -vrf ./plugins/err-example;
+            fi;
+            {{- if .Values.config.enableWebserver }}
+            echo "{'configs': {'Webserver': {'HOST': '0.0.0.0', 'PORT': {{ .Values.service.containerPort }} }}}" | errbot --storage-merge core;
+            {{- end }}
         volumeMounts:
         - name: errbot-data
           mountPath: {{ .Values.persistence.path }}
@@ -105,10 +115,12 @@ spec:
         {{- with .Values.envFrom }}
         envFrom: {{ . | toYaml | nindent 10 }}
         {{- end }}
+        {{- if .Values.config.enableWebserver }}
         ports:
           - name: http
             containerPort: {{ .Values.service.containerPort }}
             protocol: TCP
+        {{- end }}
         {{- with .Values.livenessProbe }}
         {{- if and (.enabled) ($.Values.startErrbot) }}
         livenessProbe:

--- a/charts/errbot/templates/application.yaml
+++ b/charts/errbot/templates/application.yaml
@@ -29,6 +29,7 @@ spec:
       labels:
         {{- include "errbot.selectorLabels" . | nindent 8 }}
     spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/errbot/templates/application.yaml
+++ b/charts/errbot/templates/application.yaml
@@ -91,6 +91,9 @@ spec:
         image: "{{ .repository }}:{{ .tag | default $.Chart.AppVersion }}"
         imagePullPolicy: {{ .pullPolicy }}
         {{- end }}
+        {{- if deepEqual .Values.startErrbot false }}
+        command: [sleep, infinity]
+        {{- end }}
         {{- if .Values.workingDir }}
         workingDir: {{ .Values.workingDir }}
         {{- end }}
@@ -107,7 +110,7 @@ spec:
             containerPort: {{ .Values.service.containerPort }}
             protocol: TCP
         {{- with .Values.livenessProbe }}
-        {{- if .enabled }}
+        {{- if and (.enabled) ($.Values.startErrbot) }}
         livenessProbe:
           initialDelaySeconds: {{ .initialDelaySeconds }}
           periodSeconds: {{ .periodSeconds }}

--- a/charts/errbot/templates/application.yaml
+++ b/charts/errbot/templates/application.yaml
@@ -69,6 +69,7 @@ spec:
         - |-
             export PLUGIN_DIR=$(python3 -c "import config; print(config.BOT_DATA_DIR)");
             git config --global pull.ff only;
+            mkdir -p ${PLUGIN_DIR}/plugins;
             for PLUGIN in ${PLUGIN_LIST}; do
             cd ${PLUGIN_DIR}/plugins;
             [ -e "$PLUGIN" ] && cd $PLUGIN && git pull || true;

--- a/charts/errbot/values.yaml
+++ b/charts/errbot/values.yaml
@@ -105,6 +105,8 @@ lifecycle: {}
 workingDir: /opt/errbot
 
 config:
+  # Configure Webserver plugin during initialization
+  enableWebserver: true
   existingName: ""
   type: Secret
   path: /opt/errbot/config.py

--- a/charts/errbot/values.yaml
+++ b/charts/errbot/values.yaml
@@ -3,6 +3,10 @@ kind: StatefulSet
 
 replicaCount: 1
 
+# If false, Pod will run sleep.
+# Useful for modifying data-storage settings
+startErrbot: true
+
 image:
   repository: errbotio/errbot
   tag: 6.1.9

--- a/charts/errbot/values.yaml
+++ b/charts/errbot/values.yaml
@@ -23,12 +23,16 @@ serviceAccount:
 
 automountServiceAccountToken: false
 
+tty: false
+stdin: false
+
 updateStrategy: {}
 
 podAnnotations: {}
 
 podSecurityContext: {}
-  # fsGroup: 2000
+  # fsGroup: 1000
+  # fsGroupChangePolicy: OnRootMismatch
 
 # Container Security Context
 securityContext:
@@ -88,6 +92,10 @@ livenessProbe:
   successThreshold: 1
   failureThreshold: 3
   timeoutSeconds: 1
+
+lifecycle: {}
+  # preStop: {}
+  # postStart: {}
 
 # Defaults to image (/home/errbot)
 workingDir: /opt/errbot

--- a/charts/errbot/values.yaml
+++ b/charts/errbot/values.yaml
@@ -83,9 +83,9 @@ affinity: {}
 
 terminationGracePeriodSeconds: 15
 
-# List of plugins to setup as GitHub Repositories
+# List of dict (repo) plugins to setup as GitHub Repositories
 plugins: []
-# - errbotio/err-storage-redis
+# - repo: errbotio/err-storage-redis
 
 livenessProbe:
   enabled: false
@@ -105,6 +105,16 @@ lifecycle: {}
 workingDir: /opt/errbot
 
 config:
+  # Set any configuration before running Errbot
+  storage: []
+  #- name: core
+  #  strategy: merge
+  #  values:
+  #    configs:
+  #      Webserver:
+  #        HOST: 0.0.0.0
+  #        PORT: 3141
+
   # Configure Webserver plugin during initialization
   enableWebserver: true
   existingName: ""

--- a/charts/errbot/values.yaml
+++ b/charts/errbot/values.yaml
@@ -21,6 +21,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+automountServiceAccountToken: false
+
 updateStrategy: {}
 
 podAnnotations: {}
@@ -88,18 +90,18 @@ livenessProbe:
   timeoutSeconds: 1
 
 # Defaults to image (/home/errbot)
-workingDir: ""
+workingDir: /opt/errbot
 
 config:
   existingName: ""
   type: Secret
-  path: /home/errbot/config.py
+  path: /opt/errbot/config.py
   values: |
     import logging
 
     BACKEND = "Text"
-    BOT_DATA_DIR = r"/home/errbot/data"
-    BOT_EXTRA_PLUGIN_DIR = r"/home/errbot/plugins"
+    BOT_DATA_DIR = r"/opt/errbot/data"
+    BOT_EXTRA_PLUGIN_DIR = r"/opt/errbot/plugins"
     BOT_LOG_FILE = r"/tmp/err.log"
     BOT_LOG_LEVEL = logging.INFO
     BOT_ADMINS = ("@CHANGE_ME",)
@@ -114,7 +116,7 @@ persistence:
   enabled: true
   # initialize Errbot data content
   initialize: true
-  path: /home/errbot
+  path: /opt/errbot
   size: 1Gi
   existingClaim: ""
   storageClassName: ""


### PR DESCRIPTION
- Fix data/plugins dir missing after init, needs creation
- Mounting `/home/errbot` as volume blocks `$HOME/.local/python`, so mounting by default to `/opt/errbot`.
- Disabling ServiceAccount mounting by default.
- Allow to add TTY and stdin (`kubectl attach`) and fancy colors in logs (if needed)
- Add `startErrbot` boolean to enable user interact with `errbot --storage-get` functions among others.
- Enable Webserver on bootstrap / initialize
- Allow storage configuration definition by Helm Chart
- Renamed `plugins` as list of dicts (future improvements)