### PR TITLE
Add option to add envFrom to nginx-static deployment

### DIFF
--- a/charts/nginx-static/Chart.yaml
+++ b/charts/nginx-static/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: nginx-static
 description: Deploy nginx with static pages
 type: application
-version: 0.1.3
+version: 0.1.4
 # renovate: datasource=docker depName=nginx
 appVersion: 1.23.0

--- a/charts/nginx-static/templates/deployment.yaml
+++ b/charts/nginx-static/templates/deployment.yaml
@@ -108,6 +108,10 @@ spec:
             timeoutSeconds: {{ .timeoutSeconds }}
           {{- end }}
           {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
           {{- if .Values.persistence.enabled }}
             - name: persistent-storage

--- a/charts/nginx-static/values.yaml
+++ b/charts/nginx-static/values.yaml
@@ -57,6 +57,8 @@ tolerations: []
 
 affinity: {}
 
+envFrom: []
+
 readinessProbe:
   enabled: false
   path: "/"


### PR DESCRIPTION
We need some secrets for one of our services that uses this. With this, we can add the envFrom config in the values file.

By default, it won't add `envFrom` into the manifest but when adding to the values.yaml:
```yaml
envFrom:         
  - configMapRef:
      name: env-configmap
  - secretRef:
      name: env-secrets
```

it will add so to the manifest. Based on [this](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables).