### PR TITLE
fix: bump changed-files action to v47 to fix security alert

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@v47
         with:
           files: 'charts/**'
           dir_names: true


### PR DESCRIPTION
https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/